### PR TITLE
Closes #5 - command 'extension.textFunctions' not found 

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Open up VS Code and hit `F1` and type `ext` select Install Extension and type `m
 
 # Update a selection
 
-The extension is activated when you load up a `Markdown` file and you open up a menu of commands by pressing `Alt+T`. Multi selection is supported for all commands. If you select ASCII Art you will get a secondary menu where you can choose the font.
+The extension is activated for all file types, and  you open up a menu of commands by pressing `Alt+T`. Multi selection is supported for all commands. If you select ASCII Art you will get a secondary menu where you can choose the font.
 
 
 # Known Issues

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "MDTools",
-	"description": "Text replacement functions e.g. change case, reverse and ASCII Art for Markdown.",
+	"description": "Text replacement functions e.g. change case, reverse and ASCII Art for all file types.",
 	"version": "1.0.0",
 	"publisher": "seanmcbreen",
 	"categories":[
@@ -21,7 +21,7 @@
 		"theme" : "dark"
 	},
 	"activationEvents": [
-		"onLanguage:markdown"
+		"onCommand:extension.textFunctions"
 	],
 	"engines": {
 		"vscode": "^1.0.0"


### PR DESCRIPTION
Besides the extensions name to be related to Markdown, the `README.md` says that _This extension works for all file types._. Since it's an useful extension even for non-Markdown files (like _source code_), I updated it to support any file type. 

Let 'me know if you are ok with this update, of if it should remain a Markdown only extension.
