### PR TITLE
Closes #7 - Error (in console) when there is no active file 

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -70,6 +70,12 @@ function processSelection(e: TextEditor, d: TextDocument, sel: Selection[], form
 
 // Main menu /////////////////////////////////////
 function textFunctions() {
+	
+	if (!vscode.window.activeTextEditor) {
+		vscode.window.showInformationMessage('Open a file first to manipulate text selections');
+		return;
+	}      
+	
 	var opts: QuickPickOptions = { matchOnDescription: true, placeHolder: "What do you want to do to the selection(s)?" };
 	var items: QuickPickItem[] = [];
 


### PR DESCRIPTION
It uses the same approach as other _core commands_ (`Reveal Active File in Explorer` / `Copy Path of Active File`) when there is no active file. It shows a simple `INFO` message, asking to open a file prior to running the command.
